### PR TITLE
fix: disable vercel image optimization to save resources

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ import '@/env/client';
 import '@/env/server';
 
 const nextConfig: NextConfig = {
+	images: { unoptimized: true },
 	devIndicators: false,
 };
 


### PR DESCRIPTION
## Summary
- Set `images.unoptimized` to `true` in Next.js config so `next/image` serves original sources instead of Vercel Image Optimization to save resources.